### PR TITLE
Changed shebang to portable python2

### DIFF
--- a/Client/busside.py
+++ b/Client/busside.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import struct
 import os


### PR DESCRIPTION
When running newer distros that bundle python3 by default running './busside.py' will error out as it expects python3 code.
Specifying the python version in the shebang allows './busside.py' to use python2 and the code will run as expected. 
/usr/bin/env is used so that python2 that is in the $PATH will be used to execute the file (it doesn't have to be in /usr/bin).